### PR TITLE
Formatting tweaks

### DIFF
--- a/src/features/speakers/assignment.tsx
+++ b/src/features/speakers/assignment.tsx
@@ -3,7 +3,6 @@ import { Show } from 'solid-js';
 import { Button } from '~/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip';
 import { useAssignment } from './context';
-import { useAdmin } from '../admin';
 
 export function AssignmentComponent(props: { sessionId: string }) {
   const { isAssigned } = useAssignment();
@@ -28,19 +27,16 @@ export function AssignmentComponent(props: { sessionId: string }) {
 
 function Assigned(props: { sessionId: string }) {
   const { emitUnassign } = useAssignment();
-  const { showAdminUi } = useAdmin();
   return (
     <>
-      <Show when={showAdminUi()}>
-        <Button
-          onClick={() => emitUnassign(props.sessionId)}
-          class="text-xs font-bold"
-          variant="destructive"
-          size="xs"
-        >
-          Remove Assignment
-        </Button>
-      </Show>
+      <Button
+        onClick={() => emitUnassign(props.sessionId)}
+        class="text-sm font-bold"
+        variant="destructive"
+        size="sm"
+      >
+        Remove Assignment
+      </Button>
       <Button size="sm" class="text-sm font-bold cursor-not-allowed" variant="success" disabled>
         Assigned
       </Button>

--- a/src/features/speakers/dashboard.tsx
+++ b/src/features/speakers/dashboard.tsx
@@ -355,10 +355,11 @@ function S2sInfo() {
   return (
     <>
       The Speaker-to-speaker feedback program helps speakers exchange high quality feedback for
-      their sessions with other speakers. <br />
+      their sessions with other speakers.
+      <br />
       By participating in speaker-to-speaker feedback, your session becomes available to other
       participating speakers to attend and review, and 2 speakers will assign themselves to review
-      your session. In turn, you will assign atleast 2 other sessions to yourself to attend and
+      your session. In turn, you will assign at least 2 other sessions to yourself to attend and
       review.
     </>
   );

--- a/src/features/speakers/form.tsx
+++ b/src/features/speakers/form.tsx
@@ -131,10 +131,13 @@ export function SpeakerFeedbackForm(props: { sessionId: string }) {
         </TooltipTrigger>
         <TooltipContent class="w-80">
           The Speaker Feedback Form replaces the regular feedback form for sessions that are
-          available for the Speaker-to-speaker feedback program. If you assigned this session to
-          yourself, you are required to submit feedback through this form. If you have not assigned
-          this session, you are free to still attend this session and submit your feedback through
-          this form. Once submitted, you can update your response as well.
+          available for the Speaker-to-speaker feedback program.
+          <br />
+          {isAssigned()
+            ? 'You are assigned to this session, so you are required to submit feedback for this session.'
+            : 'You are not assigned to this session, but you are free to still attend this session and submit your feedback through this form.'}
+          <br />
+          Once submitted, you can update your response as well.
         </TooltipContent>
       </Tooltip>
 


### PR DESCRIPTION
I figured this was easier than trying to describe the exact place I saw formatting errors. I wasn't able to run the app yet, so if you could do a quick test and fix any mistakes I would appreciate it! I don't have a Clerk account set up to start the app.

- Make the form tooltip dynamic to match the assignment state.
- Add a space betwen "at least" in dashboard tooltip
- Show unassign button for sessions (but not s2s as a whole)
  - Based on conversation from stand up yesterday, we will show this to speakers up until a certain date.
